### PR TITLE
Add's saving functionality to app

### DIFF
--- a/RunningApp/RunningApp.xcodeproj/project.pbxproj
+++ b/RunningApp/RunningApp.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		4E4CA75525A60A3900441F32 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4E4CA75425A60A3900441F32 /* Preview Assets.xcassets */; };
 		4E4CA76025A60A3900441F32 /* RunningAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4CA75F25A60A3900441F32 /* RunningAppTests.swift */; };
 		4E4CA76B25A60A3900441F32 /* RunningAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4CA76A25A60A3900441F32 /* RunningAppUITests.swift */; };
+		4E7260B625D6D301001E4DD5 /* RecentWorkoutRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7260B525D6D301001E4DD5 /* RecentWorkoutRepositoryTests.swift */; };
+		4E7260BB25D6D6F0001E4DD5 /* ActivityWorkoutRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7260BA25D6D6F0001E4DD5 /* ActivityWorkoutRepositoryTests.swift */; };
 		4E7E89F025CABA630099655A /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7E89EF25CABA630099655A /* LocationManager.swift */; };
 		4E7E89F525CABAC00099655A /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7E89F425CABAC00099655A /* Formatter.swift */; };
 		4E7E89FA25CABB060099655A /* UnitConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7E89F925CABB060099655A /* UnitConverter.swift */; };
@@ -25,6 +27,10 @@
 		4EB1AA9A25D3EDC6006E379D /* RecentWorkoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB1AA9925D3EDC6006E379D /* RecentWorkoutService.swift */; };
 		4EB1AA9F25D3F0E0006E379D /* RecentWorkoutRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB1AA9E25D3F0DF006E379D /* RecentWorkoutRepository.swift */; };
 		4EB1AAA425D53CBF006E379D /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB1AAA325D53CBF006E379D /* TabBarView.swift */; };
+		4EB1AAB325D6950F006E379D /* ActivityWorkoutViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB1AAB225D6950F006E379D /* ActivityWorkoutViewModelTests.swift */; };
+		4EB1AAB825D69FEE006E379D /* TimerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB1AAB725D69FEE006E379D /* TimerWrapper.swift */; };
+		4EB1AABD25D6A100006E379D /* ActivityWorkoutServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB1AABC25D6A100006E379D /* ActivityWorkoutServiceTests.swift */; };
+		4EB6672A25DA85D800B7826B /* DetailWorkoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB6672925DA85D800B7826B /* DetailWorkoutView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +63,8 @@
 		4E4CA76625A60A3900441F32 /* RunningAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunningAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4E4CA76A25A60A3900441F32 /* RunningAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningAppUITests.swift; sourceTree = "<group>"; };
 		4E4CA76C25A60A3900441F32 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4E7260B525D6D301001E4DD5 /* RecentWorkoutRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentWorkoutRepositoryTests.swift; sourceTree = "<group>"; };
+		4E7260BA25D6D6F0001E4DD5 /* ActivityWorkoutRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityWorkoutRepositoryTests.swift; sourceTree = "<group>"; };
 		4E7E89EF25CABA630099655A /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		4E7E89F425CABAC00099655A /* Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
 		4E7E89F925CABB060099655A /* UnitConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitConverter.swift; sourceTree = "<group>"; };
@@ -69,6 +77,10 @@
 		4EB1AA9925D3EDC6006E379D /* RecentWorkoutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentWorkoutService.swift; sourceTree = "<group>"; };
 		4EB1AA9E25D3F0DF006E379D /* RecentWorkoutRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentWorkoutRepository.swift; sourceTree = "<group>"; };
 		4EB1AAA325D53CBF006E379D /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
+		4EB1AAB225D6950F006E379D /* ActivityWorkoutViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityWorkoutViewModelTests.swift; sourceTree = "<group>"; };
+		4EB1AAB725D69FEE006E379D /* TimerWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerWrapper.swift; sourceTree = "<group>"; };
+		4EB1AABC25D6A100006E379D /* ActivityWorkoutServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityWorkoutServiceTests.swift; sourceTree = "<group>"; };
+		4EB6672925DA85D800B7826B /* DetailWorkoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailWorkoutView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -146,6 +158,10 @@
 			children = (
 				4E4CA75F25A60A3900441F32 /* RunningAppTests.swift */,
 				4E4CA76125A60A3900441F32 /* Info.plist */,
+				4EB1AAB225D6950F006E379D /* ActivityWorkoutViewModelTests.swift */,
+				4EB1AABC25D6A100006E379D /* ActivityWorkoutServiceTests.swift */,
+				4E7260B525D6D301001E4DD5 /* RecentWorkoutRepositoryTests.swift */,
+				4E7260BA25D6D6F0001E4DD5 /* ActivityWorkoutRepositoryTests.swift */,
 			);
 			path = RunningAppTests;
 			sourceTree = "<group>";
@@ -192,6 +208,7 @@
 				4E7E89EF25CABA630099655A /* LocationManager.swift */,
 				4E7E89F425CABAC00099655A /* Formatter.swift */,
 				4E7E89F925CABB060099655A /* UnitConverter.swift */,
+				4EB1AAB725D69FEE006E379D /* TimerWrapper.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -210,6 +227,7 @@
 				4E4CA74F25A60A3700441F32 /* RecentWorkoutView.swift */,
 				4E7E8A1425CABDC40099655A /* ActivityWorkoutView.swift */,
 				4EB1AAA325D53CBF006E379D /* TabBarView.swift */,
+				4EB6672925DA85D800B7826B /* DetailWorkoutView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -344,6 +362,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4E4CA75025A60A3700441F32 /* RecentWorkoutView.swift in Sources */,
+				4EB1AAB825D69FEE006E379D /* TimerWrapper.swift in Sources */,
 				4E4CA74E25A60A3700441F32 /* RunningAppApp.swift in Sources */,
 				4EB1AAA425D53CBF006E379D /* TabBarView.swift in Sources */,
 				4EB1AA9A25D3EDC6006E379D /* RecentWorkoutService.swift in Sources */,
@@ -353,6 +372,7 @@
 				4E7E89F525CABAC00099655A /* Formatter.swift in Sources */,
 				4EB1AA9F25D3F0E0006E379D /* RecentWorkoutRepository.swift in Sources */,
 				4E7E89FA25CABB060099655A /* UnitConverter.swift in Sources */,
+				4EB6672A25DA85D800B7826B /* DetailWorkoutView.swift in Sources */,
 				4E7E8A1525CABDC40099655A /* ActivityWorkoutView.swift in Sources */,
 				4E7E8A0425CABB590099655A /* ActivityWorkoutService.swift in Sources */,
 				4E7E89F025CABA630099655A /* LocationManager.swift in Sources */,
@@ -364,7 +384,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4E7260B625D6D301001E4DD5 /* RecentWorkoutRepositoryTests.swift in Sources */,
 				4E4CA76025A60A3900441F32 /* RunningAppTests.swift in Sources */,
+				4EB1AABD25D6A100006E379D /* ActivityWorkoutServiceTests.swift in Sources */,
+				4E7260BB25D6D6F0001E4DD5 /* ActivityWorkoutRepositoryTests.swift in Sources */,
+				4EB1AAB325D6950F006E379D /* ActivityWorkoutViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RunningApp/RunningApp.xcodeproj/xcshareddata/xcschemes/RunningApp.xcscheme
+++ b/RunningApp/RunningApp.xcodeproj/xcshareddata/xcschemes/RunningApp.xcscheme
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E4CA74925A60A3700441F32"
+               BuildableName = "RunningApp.app"
+               BlueprintName = "RunningApp"
+               ReferencedContainer = "container:RunningApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4E4CA74925A60A3700441F32"
+            BuildableName = "RunningApp.app"
+            BlueprintName = "RunningApp"
+            ReferencedContainer = "container:RunningApp.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E4CA75A25A60A3900441F32"
+               BuildableName = "RunningAppTests.xctest"
+               BlueprintName = "RunningAppTests"
+               ReferencedContainer = "container:RunningApp.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "RunningAppTests">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E4CA76525A60A3900441F32"
+               BuildableName = "RunningAppUITests.xctest"
+               BlueprintName = "RunningAppUITests"
+               ReferencedContainer = "container:RunningApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4E4CA74925A60A3700441F32"
+            BuildableName = "RunningApp.app"
+            BlueprintName = "RunningApp"
+            ReferencedContainer = "container:RunningApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4E4CA74925A60A3700441F32"
+            BuildableName = "RunningApp.app"
+            BlueprintName = "RunningApp"
+            ReferencedContainer = "container:RunningApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RunningApp/RunningApp/Helpers/TimerWrapper.swift
+++ b/RunningApp/RunningApp/Helpers/TimerWrapper.swift
@@ -1,0 +1,49 @@
+// Copyright © 2017 BBC. All rights reserved.
+
+import Foundation
+
+public protocol TimerWrapperProtocol {
+    func scheduledTimer(withTimeInterval interval: TimeInterval, repeats: Bool, block: @escaping () -> Swift.Void)
+    func endTimer()
+    var fireDate: Date? { get }
+    var hasTimer: Bool { get }
+}
+
+public class TimerWrapper: TimerWrapperProtocol {
+    
+    private var timer: Timer?
+    
+    public init() {
+        
+    }
+    
+    public var hasTimer: Bool {
+        return timer != nil
+    }
+    
+    public var fireDate: Date? {
+        return timer?.fireDate
+    }
+    
+    public func scheduledTimer(withTimeInterval interval: TimeInterval, repeats: Bool, block: @escaping () -> Swift.Void) {
+        
+        endTimer()
+        
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: repeats) { [weak self] (_) in
+           
+            if !repeats {
+                guard let strongSelf = self else { return }
+                strongSelf.endTimer()
+            }
+            
+            block()
+        }
+    }
+    
+    public func endTimer() {
+        if let timer = timer {
+            timer.invalidate()
+            self.timer = nil
+        }
+    }
+}

--- a/RunningApp/RunningApp/Repositories/ActivityWorkoutRepository.swift
+++ b/RunningApp/RunningApp/Repositories/ActivityWorkoutRepository.swift
@@ -7,13 +7,21 @@
 
 import Foundation
 
-class ActivityWorkoutRepository {
+protocol ActivityWorkoutRepositoryProtocol {
+    var locationManager: LocationManager? { get set }
+    func startWorkout()
+    func stopWorkout()
+}
+
+class ActivityWorkoutRepository: ActivityWorkoutRepositoryProtocol {
+    var locationManager: LocationManager?
     
-    private var locationManager: LocationManager?
+    
+//    private var locationManager: LocationManager?
     var distance: Measurement<UnitLength> {
         locationManager?.distance ?? Measurement(value: 0, unit: UnitLength.meters)
     }
-
+    
     init() {}
     
     func startWorkout() {

--- a/RunningApp/RunningApp/Views/ActivityWorkoutView.swift
+++ b/RunningApp/RunningApp/Views/ActivityWorkoutView.swift
@@ -52,7 +52,9 @@ struct ActivityWorkoutView: View {
 struct ActivityWorkoutView_Previews: PreviewProvider {
     
     static let activityWorkoutRepo = ActivityWorkoutRepository()
-    static let activityWorkoutService = ActivityWorkoutService(activityWorkoutRepo: activityWorkoutRepo)
+    static let timerWrapper = TimerWrapper()
+    static let workoutManager = WorkoutManager()
+    static let activityWorkoutService = ActivityWorkoutService(activityWorkoutRepo: activityWorkoutRepo, timerWrapper: timerWrapper, workoutManager: workoutManager)
     static var activityWorkoutVM = ActivityWorkoutViewModel(activityWorkoutService: activityWorkoutService)
     static var previews: some View {
         ActivityWorkoutView(activityWorkoutVM: activityWorkoutVM)

--- a/RunningApp/RunningApp/Views/TabBarView.swift
+++ b/RunningApp/RunningApp/Views/TabBarView.swift
@@ -11,8 +11,10 @@ struct TabBarView: View {
     var body: some View {
         
         let activityWorkoutRepo = ActivityWorkoutRepository()
+        let timerWrapper = TimerWrapper()
+        let workoutManager = WorkoutManager()
 
-        let activityWorkoutService = ActivityWorkoutService(activityWorkoutRepo: activityWorkoutRepo)
+        let activityWorkoutService = ActivityWorkoutService(activityWorkoutRepo: activityWorkoutRepo, timerWrapper: timerWrapper, workoutManager: workoutManager)
         
         let activityWorkoutVM = ActivityWorkoutViewModel(activityWorkoutService: activityWorkoutService)
         

--- a/RunningApp/RunningAppTests/ActivityWorkoutServiceTests.swift
+++ b/RunningApp/RunningAppTests/ActivityWorkoutServiceTests.swift
@@ -1,0 +1,174 @@
+//
+//  ActivityServiceTests.swift
+//  RunningAppTests
+//
+//  Created by Naukhez Ali on 12/02/2021.
+//
+
+import XCTest
+@testable import RunningApp
+
+class ActivityWorkoutServiceTests: XCTestCase {
+
+    var stubTimerWrapper: StubTimerWrapper!
+    var stubActivityWorkoutRepo: StubActivityWorkoutRepository!
+    var stubWorkoutUpdatedDelegate: StubWorkoutUpdatedDelegate!
+    var stubWorkoutManager: StubWorkoutManager!
+    var activityService: ActivityWorkoutService!
+    
+    override func setUp() {
+        stubActivityWorkoutRepo = StubActivityWorkoutRepository()
+        stubTimerWrapper = StubTimerWrapper()
+        stubWorkoutUpdatedDelegate = StubWorkoutUpdatedDelegate()
+        stubWorkoutManager = StubWorkoutManager()
+        activityService = ActivityWorkoutService(activityWorkoutRepo: stubActivityWorkoutRepo, timerWrapper: stubTimerWrapper, workoutManager: stubWorkoutManager)
+        activityService.workoutUpdatedDelegate = stubWorkoutUpdatedDelegate
+    }
+    
+    func testWorkoutRepoStartedWhenWorkoutStarted() {
+        activityService.startWorkout()
+        XCTAssertTrue(stubActivityWorkoutRepo.invokedStartWorkout)
+    }
+    
+    func testTimerIsScheduledWhenCallStartWorkout() {
+        activityService.startWorkout()
+        XCTAssertTrue(stubTimerWrapper.invokedScheduledTimer)
+        XCTAssertEqual(stubTimerWrapper.invokedScheduledTimerParameters?.interval, 1.0)
+    }
+    
+    func testANewWorkoutIsCreatedOnStartWorkout() {
+        
+        stubTimerWrapper.shouldInvokeScheduledTimerBlock = true
+        stubActivityWorkoutRepo.stubbedDistance = Measurement(value: 0, unit: UnitLength.meters)
+        activityService.startWorkout()
+        
+        XCTAssertTrue(stubWorkoutUpdatedDelegate.invokedWorkoutDidUpdate)
+        XCTAssertEqual(stubWorkoutUpdatedDelegate.invokedWorkoutDidUpdateCount, 1)
+        XCTAssertEqual(stubWorkoutUpdatedDelegate.invokedWorkoutDidUpdateParameters?.workout.distance, Measurement(value: 0, unit: UnitLength.meters))
+    }
+    
+    func testWorkoutDistanceIsTakenFromRepo() {
+        
+        let expectedDistance = 0.5
+        stubTimerWrapper.shouldInvokeScheduledTimerBlock = true
+        stubActivityWorkoutRepo.stubbedDistance = Measurement(value: expectedDistance, unit: UnitLength.meters)
+        activityService.startWorkout()
+        
+        XCTAssertEqual(stubWorkoutUpdatedDelegate.invokedWorkoutDidUpdateParameters?.workout.distance, Measurement(value: expectedDistance, unit: UnitLength.meters))
+    }
+
+    func testWorkoutRepoStoppedWhenWorkoutStopped() {
+        activityService.stopWorkout()
+        XCTAssertTrue(stubActivityWorkoutRepo.invokedStopWorkout)
+    }
+    
+    func testEndTimerCalledWhenWorkoutStopped() {
+        activityService.stopWorkout()
+        
+        XCTAssertTrue(stubTimerWrapper.invokedEndTimer)
+    }
+
+    func testNewWorkoutSavedWhenWorkoutStopped() {
+        
+        activityService.stopWorkout()
+        
+        XCTAssertTrue(stubWorkoutManager.invokedAdd)
+        XCTAssertEqual(stubWorkoutManager.invokedAddCount, 1)
+        
+    }
+
+}
+
+class StubTimerWrapper: TimerWrapper {
+
+    var invokedHasTimerGetter = false
+    var invokedHasTimerGetterCount = 0
+    var stubbedHasTimer: Bool! = false
+
+    override var hasTimer: Bool {
+        invokedHasTimerGetter = true
+        invokedHasTimerGetterCount += 1
+        return stubbedHasTimer
+    }
+
+    var invokedFireDateGetter = false
+    var invokedFireDateGetterCount = 0
+    var stubbedFireDate: Date!
+
+    override var fireDate: Date? {
+        invokedFireDateGetter = true
+        invokedFireDateGetterCount += 1
+        return stubbedFireDate
+    }
+
+    var invokedScheduledTimer = false
+    var invokedScheduledTimerCount = 0
+    var invokedScheduledTimerParameters: (interval: TimeInterval, repeats: Bool)?
+    var invokedScheduledTimerParametersList = [(interval: TimeInterval, repeats: Bool)]()
+    var shouldInvokeScheduledTimerBlock = false
+
+    override func scheduledTimer(withTimeInterval interval: TimeInterval, repeats: Bool, block: @escaping () -> Swift.Void) {
+        invokedScheduledTimer = true
+        invokedScheduledTimerCount += 1
+        invokedScheduledTimerParameters = (interval, repeats)
+        invokedScheduledTimerParametersList.append((interval, repeats))
+        if shouldInvokeScheduledTimerBlock {
+            _ = block()
+        }
+    }
+
+    var invokedEndTimer = false
+    var invokedEndTimerCount = 0
+
+    override func endTimer() {
+        invokedEndTimer = true
+        invokedEndTimerCount += 1
+    }
+}
+
+class StubWorkoutManager: WorkoutManager {
+
+    var invokedWorkoutsSetter = false
+    var invokedWorkoutsSetterCount = 0
+    var invokedWorkouts: [Workout]?
+    var invokedWorkoutsList = [[Workout]]()
+    var invokedWorkoutsGetter = false
+    var invokedWorkoutsGetterCount = 0
+    var stubbedWorkouts: [Workout]! = []
+
+    override var workouts: [Workout] {
+        set {
+            invokedWorkoutsSetter = true
+            invokedWorkoutsSetterCount += 1
+            invokedWorkouts = newValue
+            invokedWorkoutsList.append(newValue)
+        }
+        get {
+            invokedWorkoutsGetter = true
+            invokedWorkoutsGetterCount += 1
+            return stubbedWorkouts
+        }
+    }
+
+    var invokedLoad = false
+    var invokedLoadCount = 0
+    var stubbedLoadResult: [Workout]! = []
+
+    override func load() -> [Workout] {
+        invokedLoad = true
+        invokedLoadCount += 1
+        return stubbedLoadResult
+    }
+
+    var invokedAdd = false
+    var invokedAddCount = 0
+    var invokedAddParameters: (newWorkout: Workout, Void)?
+    var invokedAddParametersList = [(newWorkout: Workout, Void)]()
+
+    override func add(_ newWorkout: Workout) {
+        invokedAdd = true
+        invokedAddCount += 1
+        invokedAddParameters = (newWorkout, ())
+        invokedAddParametersList.append((newWorkout, ()))
+    }
+}

--- a/RunningApp/RunningAppTests/ActivityWorkoutViewModelTests.swift
+++ b/RunningApp/RunningAppTests/ActivityWorkoutViewModelTests.swift
@@ -1,0 +1,150 @@
+//
+//  ActivityWorkoutViewModelTests.swift
+//  RunningAppTests
+//
+//  Created by Naukhez Ali on 12/02/2021.
+//
+
+import XCTest
+@testable import RunningApp
+
+class ActivityWorkoutViewModelTests: XCTestCase {
+    
+    var activityWorkoutVM: ActivityWorkoutViewModel!
+    var stubActivityWorkoutService: StubActivityWorkoutService!
+    var stubActivityWorkoutUpdatedDelegate: StubWorkoutUpdatedDelegate!
+    var stubActivityWorkoutRepo: StubActivityWorkoutRepository!
+    var stubTimerWrapper: StubTimerWrapper!
+    var stubWorkoutManager: StubWorkoutManager!
+    
+    override func setUp() {
+        stubActivityWorkoutRepo = StubActivityWorkoutRepository()
+        stubTimerWrapper = StubTimerWrapper()
+        stubWorkoutManager = StubWorkoutManager()
+        
+        stubActivityWorkoutService = StubActivityWorkoutService(activityWorkoutRepo: stubActivityWorkoutRepo, timerWrapper: stubTimerWrapper, workoutManager: stubWorkoutManager)
+        
+        activityWorkoutVM = ActivityWorkoutViewModel(activityWorkoutService: stubActivityWorkoutService)
+        
+        stubActivityWorkoutUpdatedDelegate = StubWorkoutUpdatedDelegate()
+        
+        stubActivityWorkoutService.workoutUpdatedDelegate = stubActivityWorkoutUpdatedDelegate
+    }
+    
+    func testSuccessfullyCallsStartWorkoutInService() {
+        activityWorkoutVM.startWorkout()
+        XCTAssertTrue(stubActivityWorkoutService.invokedStartWorkout)
+    }
+    
+    func testCallsStopWorkoutInService() {
+        activityWorkoutVM.stopWorkout()
+        
+        XCTAssertTrue(stubActivityWorkoutService.invokedStopWorkout)
+    }
+    
+    func testWorkoutUpdatedDelegateFormatsNewWorkoutObject() {
+        let expectedDistance = Measurement(value: 0, unit: UnitLength.meters)
+        let expectedWorkout = Workout(distance: expectedDistance, startTime: Date())
+        
+        let formattedDistance = FormatDisplay.distance(expectedDistance)
+        
+        activityWorkoutVM.workoutDidUpdate(workout: expectedWorkout)
+        
+        
+        XCTAssertEqual(activityWorkoutVM.distance, formattedDistance)
+    }
+    
+}
+
+class StubActivityWorkoutRepository: ActivityWorkoutRepository {
+
+    var invokedDistanceGetter = false
+    var invokedDistanceGetterCount = 0
+    var stubbedDistance: Measurement<UnitLength>!
+
+    override var distance: Measurement<UnitLength> {
+        invokedDistanceGetter = true
+        invokedDistanceGetterCount += 1
+        return stubbedDistance
+    }
+
+    var invokedStartWorkout = false
+    var invokedStartWorkoutCount = 0
+
+    override func startWorkout() {
+        invokedStartWorkout = true
+        invokedStartWorkoutCount += 1
+    }
+
+    var invokedStopWorkout = false
+    var invokedStopWorkoutCount = 0
+
+    override func stopWorkout() {
+        invokedStopWorkout = true
+        invokedStopWorkoutCount += 1
+    }
+}
+
+class StubWorkoutUpdatedDelegate: WorkoutUpdatedDelegate {
+
+    var invokedWorkoutDidUpdate = false
+    var invokedWorkoutDidUpdateCount = 0
+    var invokedWorkoutDidUpdateParameters: (workout: Workout, Void)?
+    var invokedWorkoutDidUpdateParametersList = [(workout: Workout, Void)]()
+
+    func workoutDidUpdate(workout: Workout) {
+        invokedWorkoutDidUpdate = true
+        invokedWorkoutDidUpdateCount += 1
+        invokedWorkoutDidUpdateParameters = (workout, ())
+        invokedWorkoutDidUpdateParametersList.append((workout, ()))
+    }
+}
+
+class StubActivityWorkoutService: ActivityWorkoutService {
+
+    var invokedWorkoutUpdatedDelegateSetter = false
+    var invokedWorkoutUpdatedDelegateSetterCount = 0
+    var invokedWorkoutUpdatedDelegate: WorkoutUpdatedDelegate?
+    var invokedWorkoutUpdatedDelegateList = [WorkoutUpdatedDelegate?]()
+    var invokedWorkoutUpdatedDelegateGetter = false
+    var invokedWorkoutUpdatedDelegateGetterCount = 0
+    var stubbedWorkoutUpdatedDelegate: WorkoutUpdatedDelegate!
+
+    override var workoutUpdatedDelegate: WorkoutUpdatedDelegate? {
+        set {
+            invokedWorkoutUpdatedDelegateSetter = true
+            invokedWorkoutUpdatedDelegateSetterCount += 1
+            invokedWorkoutUpdatedDelegate = newValue
+            invokedWorkoutUpdatedDelegateList.append(newValue)
+        }
+        get {
+            invokedWorkoutUpdatedDelegateGetter = true
+            invokedWorkoutUpdatedDelegateGetterCount += 1
+            return stubbedWorkoutUpdatedDelegate
+        }
+    }
+
+    var invokedStartWorkout = false
+    var invokedStartWorkoutCount = 0
+
+    override func startWorkout() {
+        invokedStartWorkout = true
+        invokedStartWorkoutCount += 1
+    }
+
+    var invokedStopWorkout = false
+    var invokedStopWorkoutCount = 0
+
+    override func stopWorkout() {
+        invokedStopWorkout = true
+        invokedStopWorkoutCount += 1
+    }
+
+    var invokedPauseWorkout = false
+    var invokedPauseWorkoutCount = 0
+
+    override func pauseWorkout() {
+        invokedPauseWorkout = true
+        invokedPauseWorkoutCount += 1
+    }
+}

--- a/RunningApp/RunningAppTests/RecentWorkoutRepositoryTests.swift
+++ b/RunningApp/RunningAppTests/RecentWorkoutRepositoryTests.swift
@@ -1,0 +1,28 @@
+//
+//  RecentWorkoutRepositoryTests.swift
+//  RunningAppTests
+//
+//  Created by Naukhez Ali on 12/02/2021.
+//
+
+import XCTest
+@testable import RunningApp
+class RecentWorkoutRepositoryTests: XCTestCase {
+    
+    var stubWorkoutManager: StubWorkoutManager!
+    var recentWorkoutRepository: RecentWorkoutRepository!
+    override func setUp() {
+        stubWorkoutManager = StubWorkoutManager()
+        recentWorkoutRepository = RecentWorkoutRepository()
+    }
+    
+    func testWorkoutManagerReturnsNilWhenNoWorkoutsInStore() {
+        stubWorkoutManager.stubbedLoadResult = []
+        
+        let expectedWorkoutInStore: [Workout] = []
+        
+        let actualWorkoutsInStore = recentWorkoutRepository.workouts
+        
+        XCTAssertEqual(expectedWorkoutInStore.count, actualWorkoutsInStore.count)
+    }
+}


### PR DESCRIPTION
This PR does the following
- It allows the user to save new workouts
- Saved workouts can then be retrieved and displayed inside recentWorkoutView. These workouts are displayed in a list view.
- Added a TimerWrapper class. Which allows the timerWrapper functionality inside the services to be tested easily.
- ActiveWorkoutRepo now conforms to a protocol. 
- View Models, Services and Repo's now have unit tests.